### PR TITLE
Fix duplicate escape

### DIFF
--- a/request.go
+++ b/request.go
@@ -90,7 +90,7 @@ func (amazonPay *AmazonPay) buildPostURL(params Params) string {
 
 	for key, value := range params {
 		if str := fmt.Sprint(value); str != "" {
-			apiParams = append(apiParams, key+"="+url.QueryEscape(url.PathEscape(str)))
+			apiParams = append(apiParams, key+"="+url.QueryEscape(str))
 		}
 	}
 


### PR DESCRIPTION
A parameter of a request will be escaped multiple times, so multi-byte characters will not be displayed correctly on Amazon Pay Seller Central page.
This pull-request fixes it.